### PR TITLE
rpm: add autoconf-archive as a BuildRequires

### DIFF
--- a/rpmbuild/libzbd.spec.in
+++ b/rpmbuild/libzbd.spec.in
@@ -11,6 +11,7 @@ URL:		https://github.com/westerndigitalcorporation/libzbd
 Source:         %{name}-%{version}.tar.gz
 
 BuildRequires:  autoconf
+BuildRequires:  autoconf-archive
 BuildRequires:  automake
 BuildRequires:  libtool
 BuildRequires:  gcc


### PR DESCRIPTION
AX_CHECK_ENABLE_DEBUG() m4 macro is used by configure, but this script
is offered by ax_check_enable_debug.m4. see
https://www.gnu.org/software/autoconf-archive/ax_check_enable_debug.html.
which is in turn packaged by autoconf-archive package. see
https://pkgs.org/search/?q=ax_check_enable_debug.m4.

so we need to add autoconf-archive as a build dependency.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>