### PR TITLE
lib: Small fixes

### DIFF
--- a/lib/zbd.c
+++ b/lib/zbd.c
@@ -720,7 +720,7 @@ int zbd_zones_operation(int fd, enum zbd_zone_op op, off_t ofst, off_t len)
 			return -1;
 		}
 #else
-		zbd_error("BLKCLOSEZONE ioctl is not supported\n");
+		zbd_error("BLKOPENZONE ioctl is not supported\n");
 		errno = -ENOTSUP;
 		return -1;
 #endif
@@ -750,7 +750,7 @@ int zbd_zones_operation(int fd, enum zbd_zone_op op, off_t ofst, off_t len)
 			return -1;
 		}
 #else
-		zbd_error("BLKCLOSEZONE ioctl is not supported\n");
+		zbd_error("BLKFINISHZONE ioctl is not supported\n");
 		errno = -ENOTSUP;
 		return -1;
 #endif

--- a/lib/zbd.c
+++ b/lib/zbd.c
@@ -407,8 +407,11 @@ int zbd_open(const char *filename, int flags, struct zbd_info *info)
 	return fd;
 
 err:
-	if (fd >= 0)
+	if (fd >= 0) {
 		close(fd);
+		fd = -1;
+	}
+
 	free(path);
 
 	return fd;


### PR DESCRIPTION
If zbd_open fails to get device information, the closed fd can be returned.

Also fix some typos in error messages.