### PR TITLE
lib: Fixed memory leak in zbd_open() caused by realpath()

### DIFF
--- a/lib/zbd.c
+++ b/lib/zbd.c
@@ -404,6 +404,8 @@ int zbd_open(const char *filename, int flags, struct zbd_info *info)
 	if (info)
 		memcpy(info, zbdi, sizeof(struct zbd_info));
 
+	free(path);
+
 	return fd;
 
 err:


### PR DESCRIPTION
According to the 'realpath()' man page this function when called
with 'NULL' for the second parameter allocates a buffer with 'malloc()'
and it's the caller's responsibility to deallocate the memory with
'free()'.

'zbd_open()' does this on all error paths but not in the successful one.
Fixed by adding a call to 'free(path);' just before return.

Signed-off-by: Yura Sorokin <yura.sorokin@percona.com>