### PR TITLE
Sync debian packaging files

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,33 @@
+libzbd (2.0.2-2) unstable; urgency=medium
+
+  * Source only upload.
+
+ -- Sudip Mukherjee <sudipm.mukherjee@gmail.com>  Tue, 15 Feb 2022 22:02:14 +0000
+
+libzbd (2.0.2-1) unstable; urgency=medium
+
+  [ Debian Janitor ]
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
+  * Update standards version to 4.6.0, no changes needed.
+
+  [ Sudip Mukherjee ]
+  * New upstream version 2.0.2
+    - Update version for SONAME change.
+    - Update symbols.
+  * Update Standards-Version to 4.6.0.1
+
+ -- Sudip Mukherjee <sudipm.mukherjee@gmail.com>  Mon, 14 Feb 2022 14:23:27 +0000
+
+libzbd (1.5.0-1) unstable; urgency=medium
+
+  * Upload to unstable.
+  * New upstream version 1.5.0
+    - Update installed library name.
+    - Update library name in symbols.
+
+ -- Sudip Mukherjee <sudipm.mukherjee@gmail.com>  Wed, 18 Aug 2021 23:00:07 +0100
+
 libzbd (1.4.0-1) experimental; urgency=medium
 
   * New upstream version 1.4.0

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: libzbd
 Priority: optional
 Maintainer: Sudip Mukherjee <sudipm.mukherjee@gmail.com>
 Build-Depends: debhelper-compat (= 13), autoconf-archive, libgtk-3-dev
-Standards-Version: 4.5.1
+Standards-Version: 4.6.0.1
 Section: libs
 Homepage: https://zonedstorage.io/projects/libzbd/
 Vcs-Browser: https://salsa.debian.org/sudip/libzbd
@@ -12,7 +12,7 @@ Package: libzbd-dev
 Section: libdevel
 Architecture: linux-any
 Multi-Arch: same
-Depends: libzbd1 (= ${binary:Version}), ${misc:Depends}
+Depends: libzbd2 (= ${binary:Version}), ${misc:Depends}
 Description: Library to manipulate zoned block devices (development files)
  libzbd uses the kernel provided zoned block device interface based on the
  ioctl() system call. It provides functions for discovering and managing the
@@ -21,7 +21,7 @@ Description: Library to manipulate zoned block devices (development files)
  .
  This package is needed to compile programs against libzbd.
 
-Package: libzbd1
+Package: libzbd2
 Architecture: linux-any
 Multi-Arch: same
 Depends: ${shlibs:Depends}, ${misc:Depends}

--- a/debian/libzbd1.install
+++ b/debian/libzbd1.install
@@ -1,1 +1,0 @@
-usr/lib/*/libzbd-*.so

--- a/debian/libzbd2.install
+++ b/debian/libzbd2.install
@@ -1,0 +1,1 @@
+usr/lib/*/libzbd.so.*

--- a/debian/libzbd2.symbols
+++ b/debian/libzbd2.symbols
@@ -1,8 +1,9 @@
-libzbd-1.4.0.so libzbd1 #MINVER#
+libzbd.so.2 libzbd2 #MINVER#
  ZBD_GLOBAL@ZBD_GLOBAL 1.1.0
  zbd_close@ZBD_GLOBAL 1.1.0
  zbd_device_is_zoned@ZBD_GLOBAL 1.1.0
  zbd_device_model_str@ZBD_GLOBAL 1.1.0
+ zbd_get_info@ZBD_GLOBAL 2.0.2
  zbd_list_zones@ZBD_GLOBAL 1.1.0
  zbd_open@ZBD_GLOBAL 1.1.0
  zbd_report_zones@ZBD_GLOBAL 1.1.0

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,5 @@
+---
+Bug-Database: https://github.com/westerndigitalcorporation/libzbd/issues
+Bug-Submit: https://github.com/westerndigitalcorporation/libzbd/issues/new
+Repository: https://github.com/westerndigitalcorporation/libzbd.git
+Repository-Browse: https://github.com/westerndigitalcorporation/libzbd


### PR DESCRIPTION
Sync the Debian packaging files in debian/* as of Debian package version 2.0.2-2.
Link: https://tracker.debian.org/pkg/libzbd
Source: https://salsa.debian.org/sudip/libzbd