### PR TITLE
Fix warning unitialized variable `ret` in `zbd_report_zones`

### DIFF
--- a/lib/zbd.c
+++ b/lib/zbd.c
@@ -528,7 +528,7 @@ int zbd_report_zones(int fd, off_t ofst, off_t len, enum zbd_report_option ro,
 	unsigned int nrz, n = 0, i = 0;
 	struct blk_zone *blkz;
 	struct zbd_zone z;
-	int ret;
+	int ret = 0;
 
 	if (!zbdi) {
 		zbd_error("Invalid file descriptor %d\n\n", fd);


### PR DESCRIPTION
Initialize variable `ret` to avoid the following warning:

```
/libzbd/lib/zbd.c:625:9: error:
variable 'ret' may be uninitialized when used here
[-Werror,-Wconditional-uninitialized]
        return ret;
```
